### PR TITLE
run dependency review on PR merge, to synchronise Security tab with main rather than branch

### DIFF
--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -2,6 +2,8 @@ name: 'Dependency Review'
 on:
   pull_request:
     branches: '**'
+  push:
+    branches: 'main'
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently Security tab shows vulnerabilities from the last time `actions/dependency-review-action` ran, which is set to a PR being opened or synchronised. This is despite vulnerability fixes being merged to main.

This change runs the action again when the PR is merged, to update the dependency information back to main branch.

![Screenshot 2025-03-26 at 12 16 59](https://github.com/user-attachments/assets/3469b8b1-014b-4ee8-8049-50c13e9379d4)